### PR TITLE
Fix the regex that catches for a for loop.

### DIFF
--- a/shlomobot_pytest/common_tests.py
+++ b/shlomobot_pytest/common_tests.py
@@ -24,7 +24,7 @@ import pytest
 
 WHILE_LOOP_REGEX = re.compile(r"while\s+.+")
 WITH_OPEN_REGEX = re.compile(r"with\s+open\(['\"]")
-FOR_LOOP_REGEX = re.compile(r"for\s+\w+\s+in\s+\w+")
+FOR_LOOP_REGEX = re.compile(r"for\s+\w+\s+in\s+")
 LAMBDA_REGEX = re.compile(r"lambda (?:[^\s]*? ?, ?)*?\w+\s*:")
 ASSERT_REGEX = re.compile(r"^[ \t]*assert[ \t]*\w+")
 


### PR DESCRIPTION
The current regex is `for\s+\w+\s+in\s+\w+` which will pass for element in list  but will fail for element in [1, 2, 3]
A suggestion for the improved regex is `for\s+\w+\s+in\s+` as it ensures that the statement contains the "for" and "in" keywords.