### PR TITLE
Modify for-loop regex to match non alphanumeric characters

### DIFF
--- a/shlomobot_pytest/common_tests.py
+++ b/shlomobot_pytest/common_tests.py
@@ -24,7 +24,7 @@ import pytest
 
 WHILE_LOOP_REGEX = re.compile(r"while\s+.+")
 WITH_OPEN_REGEX = re.compile(r"with\s+open\(['\"]")
-FOR_LOOP_REGEX = re.compile(r"for\s+\w+\s+in\s+\w+")
+FOR_LOOP_REGEX = re.compile(r"for \S+ in .*:")
 LAMBDA_REGEX = re.compile(r"lambda (?:[^\s]*? ?, ?)*?\w+\s*:")
 ASSERT_REGEX = re.compile(r"^[ \t]*assert[ \t]*\w+")
 


### PR DESCRIPTION
This fixes 2 things:
1. Not matching for loops when non alphanumeric characters are used in the iterable, e.g.

```py
for i in [1, 2, 3]:
```

2. Incorrectly matching list comprehensions as for-loops, e.g.
```py
nums = [i for i in range(1, 100)]
```