### PR TITLE
Rename test_function_exists_and_contains_asserts

### DIFF
--- a/shlomobot_pytest/common_tests.py
+++ b/shlomobot_pytest/common_tests.py
@@ -173,11 +173,10 @@ def correct_imports_are_made(py_filename: str, import_list: list[str]) -> bool:
     return all([module in imported_modules for module in import_list])
 
 
-@pytest.mark.skip("Not a pytest function")
-def test_function_exists_and_contains_asserts(py_filename: str) -> bool:
+def check_test_function_exists_and_contains_asserts(py_filename: str) -> bool:
     """
     Checks that the module contains a test function that uses assert.
-    
+
     The test function must be named `test`
     """
 
@@ -191,6 +190,22 @@ def test_function_exists_and_contains_asserts(py_filename: str) -> bool:
         return function_contains_regex(ASSERT_REGEX, test_function)
     except AttributeError:
         return False
+
+
+@pytest.mark.skip(("Not a pytest function. This function is "
+                   "deprecated and usages should be replaced "
+                   "with check_test_function_exists_and_contains_asserts"))
+def test_function_exists_and_contains_asserts(py_filename: str) -> bool:
+    """
+    This function is deprecated and usages should be replaced with
+    check_test_function_exists_and_contains_asserts
+
+    Checks that the module contains a test function that uses assert.
+
+    The test function must be named `test`
+    """
+
+    return check_test_function_exists_and_contains_asserts(py_filename)
 
 
 def function_contains_input(function: FunctionType) -> bool:

--- a/shlomobot_pytest/common_tests.py
+++ b/shlomobot_pytest/common_tests.py
@@ -192,22 +192,6 @@ def check_test_function_exists_and_contains_asserts(py_filename: str) -> bool:
         return False
 
 
-@pytest.mark.skip(("Not a pytest function. This function is "
-                   "deprecated and usages should be replaced "
-                   "with check_test_function_exists_and_contains_asserts"))
-def test_function_exists_and_contains_asserts(py_filename: str) -> bool:
-    """
-    This function is deprecated and usages should be replaced with
-    check_test_function_exists_and_contains_asserts
-
-    Checks that the module contains a test function that uses assert.
-
-    The test function must be named `test`
-    """
-
-    return check_test_function_exists_and_contains_asserts(py_filename)
-
-
 def function_contains_input(function: FunctionType) -> bool:
     """
     Checks if a given function contains a call to the builtin


### PR DESCRIPTION
Rename the function `test_function_exists_and_contains_asserts` to `check_test_function_exists_and_contains_asserts`.

This prevents the function from being picked up by pytest as a test function, allowing us to remove the `@pytest.mark.skip` decorator. This lets us remove the skipped test entry in tests where this function is imported, and thus causing less confusion when developing tests.

This PR should be merged at the same time as https://github.com/DARTSG/materials/pull/140